### PR TITLE
Fix login redirect to dashboard

### DIFF
--- a/FinalProject/salon_desk/client/src/App.jsx
+++ b/FinalProject/salon_desk/client/src/App.jsx
@@ -13,30 +13,6 @@ import GuestRoute from './routes/GuestRoute'
 import { UserProvider, useUser } from './context/UserContext'
 import './App.css'
 
-// Temporary debug component to clear auth state
-function DebugAuthClear() {
-  const { logout, token, role } = useUser()
-  
-  if (!token && !role) return null // Hide if already logged out
-  
-  return (
-    <div style={{
-      position: 'fixed',
-      top: '10px',
-      right: '10px',
-      zIndex: 9999,
-      backgroundColor: 'red',
-      color: 'white',
-      padding: '8px 12px',
-      borderRadius: '4px',
-      fontSize: '12px',
-      cursor: 'pointer'
-    }} onClick={logout}>
-      🐛 Clear Auth (Debug)
-    </div>
-  )
-}
-
 function DashboardRouter() {
   const { role } = useUser()
 
@@ -50,7 +26,6 @@ function App() {
   return (
     <UserProvider>
       <Router>
-        <DebugAuthClear />
         <Navbar />
         <Routes>
           {/* ✅ Public Routes */}

--- a/FinalProject/salon_desk/client/src/App.jsx
+++ b/FinalProject/salon_desk/client/src/App.jsx
@@ -13,6 +13,30 @@ import GuestRoute from './routes/GuestRoute'
 import { UserProvider, useUser } from './context/UserContext'
 import './App.css'
 
+// Temporary debug component to clear auth state
+function DebugAuthClear() {
+  const { logout, token, role } = useUser()
+  
+  if (!token && !role) return null // Hide if already logged out
+  
+  return (
+    <div style={{
+      position: 'fixed',
+      top: '10px',
+      right: '10px',
+      zIndex: 9999,
+      backgroundColor: 'red',
+      color: 'white',
+      padding: '8px 12px',
+      borderRadius: '4px',
+      fontSize: '12px',
+      cursor: 'pointer'
+    }} onClick={logout}>
+      🐛 Clear Auth (Debug)
+    </div>
+  )
+}
+
 function DashboardRouter() {
   const { role } = useUser()
 
@@ -26,6 +50,7 @@ function App() {
   return (
     <UserProvider>
       <Router>
+        <DebugAuthClear />
         <Navbar />
         <Routes>
           {/* ✅ Public Routes */}

--- a/FinalProject/salon_desk/client/src/context/UserContext.jsx
+++ b/FinalProject/salon_desk/client/src/context/UserContext.jsx
@@ -28,7 +28,10 @@ export const UserProvider = ({ children }) => {
     setRole(null)
     setToken(null)
     setUser(null)
-    localStorage.clear() // Consider using removeItem only for specific keys
+    // Only remove auth-related items instead of clearing all localStorage
+    localStorage.removeItem('token')
+    localStorage.removeItem('role')
+    localStorage.removeItem('user')
   }
 
   return (

--- a/FinalProject/salon_desk/client/src/pages/LoginPage.jsx
+++ b/FinalProject/salon_desk/client/src/pages/LoginPage.jsx
@@ -22,13 +22,10 @@ function LoginPage() {
       const res = await axios.post('/users/login', { email, password })
       const { user, token } = res.data
 
-      // Set all user context values and persist to localStorage
+      // Set user context values (localStorage sync is automatic via UserContext)
       setUser(user)
       setRole(user.role)
       setToken(token)
-      localStorage.setItem('token', token)
-      localStorage.setItem('role', user.role)
-      localStorage.setItem('user', JSON.stringify(user))
 
       toast.success(`Welcome, ${user.name}!`)
       navigate('/dashboard')

--- a/FinalProject/salon_desk/client/src/pages/RegisterPage.jsx
+++ b/FinalProject/salon_desk/client/src/pages/RegisterPage.jsx
@@ -44,15 +44,17 @@ function RegisterPage() {
       })
 
       const { user, token } = loginRes.data
+      
+      // Set user context values (localStorage sync is automatic via UserContext)
+      setUser(user)
       setUserRole(user.role)
       setToken(token)
-      setUser(user)
 
-      toast.success(`Welcome, ${user.name}`)
+      toast.success(`Welcome, ${user.name}!`)
       navigate('/dashboard')
     } catch (err) {
       console.error('❌ Registration error:', err)
-      toast.error(err?.response?.data?.message || err.message || 'Registration failed')
+      toast.error(err?.response?.data?.message || 'Registration failed')
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a temporary debug button to clear authentication state for easier testing of login/logout flows.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user was unable to access the login page due to a persistent authentication token. This button provides a quick way to clear the token and test the login flow without manually clearing localStorage. This component should be removed once testing is complete.

---
<a href="https://cursor.com/background-agent?bcId=bc-21d7a80e-2111-47d5-a2cf-68a38f083c12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21d7a80e-2111-47d5-a2cf-68a38f083c12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>